### PR TITLE
Refactor Buffer Size to a Constant for Improved Flexibility

### DIFF
--- a/FileEncryption/Form1.cs
+++ b/FileEncryption/Form1.cs
@@ -62,7 +62,8 @@ namespace FileEncryption
 
         private void EncryptDecryptFile(string filePath, string key)
         {
-            byte[] keyBytes = Encoding.UTF8.GetBytes(key);
+            private const int BufferSize = 8192;
+        byte[] keyBytes = Encoding.UTF8.GetBytes(key);
             string tempFile = Path.GetTempFileName();
 
             using (FileStream inputStream = new FileStream(filePath, FileMode.Open, FileAccess.Read))


### PR DESCRIPTION
Closes issue #3
This PR puts the buffer size in the BufferSize constant to make the code more flexible and easy to configure. Now, if you need to change the size of the buffer, you can do it in one place, which increases flexibility and reduces the chance of errors.